### PR TITLE
[#1] 회원 인증 구현 및 세팅 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	testImplementation 'org.testcontainers:testcontainers'
 	implementation 'com.github.codemonstur:embedded-redis:1.4.0'
 

--- a/src/main/java/com/around/tdd/TddApplication.java
+++ b/src/main/java/com/around/tdd/TddApplication.java
@@ -2,8 +2,10 @@ package com.around.tdd;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan(basePackages = "com.around.tdd.property")
 public class TddApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/around/tdd/config/MailConfig.java
+++ b/src/main/java/com/around/tdd/config/MailConfig.java
@@ -1,0 +1,48 @@
+package com.around.tdd.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailConfig {
+
+    @Value("${mail.protocol}")
+    private String protocol;
+
+    @Value("${mail.host}")
+    private String host;
+
+    @Value("${mail.port}")
+    private Integer port;
+
+    @Value("${mail.username}")
+    private String username;
+
+    @Value("${mail.password}")
+    private String password;
+
+    @Bean
+    public JavaMailSenderImpl mailSender() {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+        javaMailSender.setProtocol(protocol);
+        javaMailSender.setHost(host);
+        javaMailSender.setPort(port);
+        javaMailSender.setUsername(username);
+        javaMailSender.setPassword(password);
+        javaMailSender.setJavaMailProperties(this.getProperties());
+        return javaMailSender;
+    }
+
+
+    private Properties getProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("mail.smtp.auth", "true");
+        properties.setProperty("mail.smtp.starttls.enable", "true");
+        return properties;
+    }
+
+}

--- a/src/main/java/com/around/tdd/controller/AuthController.java
+++ b/src/main/java/com/around/tdd/controller/AuthController.java
@@ -1,0 +1,91 @@
+package com.around.tdd.controller;
+
+import com.around.tdd.service.AuthService;
+import com.around.tdd.service.EmailSendService;
+import com.around.tdd.service.MemberService;
+import com.around.tdd.util.HttpUtil;
+import com.around.tdd.vo.MailDto;
+import com.around.tdd.vo.Member;
+import com.around.tdd.vo.MemberRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+@Tag(name = "Auth", description = "Auth 관련 API 입니다.")
+public class AuthController {
+
+    private final AuthService authService;
+
+    private final EmailSendService emailSendService;
+
+    private final MemberService memberService;
+
+    @Operation(
+            summary = "인증번호 생성 및 이메일 발송"
+    )
+    @ApiResponses(value = {
+            @ApiResponse( responseCode = "201", description = "인증번호 생성 후 저장됨"),
+            @ApiResponse( responseCode = "204", description = "해당 memberSeq는 사용자가 존재 하지 않음")
+        }
+    )
+    @PostMapping("/auth-number")
+    public ResponseEntity<String> authNumber(@RequestBody MemberRequest memberRequest) {
+        Optional<Member> optionalMember = memberService.memberFindById(memberRequest.getMemberSeq());
+        if(!optionalMember.isPresent()) {
+            return new ResponseEntity<>("사용자 정보가 없음",HttpUtil.createJsonHeaders(), HttpStatus.NO_CONTENT);
+        }
+        Member member = optionalMember.get();
+        String authNumber = authService.getAuthNumber();
+        authService.saveAuth("auth-member:"+memberRequest.getMemberSeq(), authNumber);
+        emailSendService.sendSimpleMessage(new MailDto("tdd@gmail.com", member.getMemberInfo().getEmail(), "인증번호", "인증번호:"+authNumber));
+        return new ResponseEntity<>("인증번호 저장 성공",HttpUtil.createJsonHeaders(), HttpStatus.CREATED);
+    }
+
+    @Operation(
+            summary = "인증번호 확인 메소드"
+    )
+    @ApiResponses(value = {
+            @ApiResponse( responseCode = "201", description = "인증 토큰 생성 후 저장 및 반환"),
+            @ApiResponse( responseCode = "204", description = "인증번호가 일치 하는 사용자가 없음")
+        }
+    )
+    @PostMapping("/auth-check")
+    public ResponseEntity<String> authCheck(@RequestBody MemberRequest memberRequest) {
+        boolean authCheck = authService.matchAuth("auth-member:"+memberRequest.getMemberSeq(), memberRequest.getAuthNumber());
+        if(!authCheck){
+            return new ResponseEntity<>(String.valueOf(false),HttpUtil.createJsonHeaders(), HttpStatus.NO_CONTENT);
+        }
+
+        String token = authService.getToken(memberRequest.getMemberSeq().intValue());
+
+        authService.saveAuth("auth-token:"+memberRequest.getMemberSeq(), token);
+        return new ResponseEntity<>(token,HttpUtil.createJsonHeaders(), HttpStatus.CREATED);
+    }
+
+    @Operation(
+            summary = "인증토큰 확인 메소드"
+    )
+    @ApiResponses(value = {
+            @ApiResponse( responseCode = "200", description = "인증 토큰 일치"),
+            @ApiResponse( responseCode = "204", description = "인증토큰이 일치 하는 사용자가 없음")
+    }
+    )
+    @GetMapping("/auth-token-check")
+    public ResponseEntity<String> authTokenCheck(
+            @RequestParam Long memberSeq,
+            @RequestParam String authToken
+    ) {
+        boolean authCheck = authService.matchAuth("auth-token:"+memberSeq, authToken);
+        return new ResponseEntity<>(String.valueOf(authCheck), HttpUtil.createJsonHeaders(), authCheck ? HttpStatus.OK : HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/com/around/tdd/property/AuthProperty.java
+++ b/src/main/java/com/around/tdd/property/AuthProperty.java
@@ -1,0 +1,12 @@
+package com.around.tdd.property;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "auth-property")
+@RequiredArgsConstructor
+@Getter
+public class AuthProperty {
+    private final String salt;
+}

--- a/src/main/java/com/around/tdd/repository/AuthRedisRepository.java
+++ b/src/main/java/com/around/tdd/repository/AuthRedisRepository.java
@@ -1,0 +1,7 @@
+package com.around.tdd.repository;
+
+import com.around.tdd.vo.RedisAuth;
+import org.springframework.data.repository.CrudRepository;
+
+public interface AuthRedisRepository extends CrudRepository<RedisAuth, String> {
+}

--- a/src/main/java/com/around/tdd/repository/MemberRepository.java
+++ b/src/main/java/com/around/tdd/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.around.tdd.repository;
+
+import com.around.tdd.vo.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/around/tdd/service/AuthService.java
+++ b/src/main/java/com/around/tdd/service/AuthService.java
@@ -1,0 +1,82 @@
+package com.around.tdd.service;
+
+import com.around.tdd.property.AuthProperty;
+import com.around.tdd.repository.AuthRedisRepository;
+import com.around.tdd.vo.RedisAuth;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.springframework.stereotype.Service;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final AuthRedisRepository authRedisRepository;
+
+    private final AuthProperty authProperty;
+
+    /**
+     * 인증관련 레디스 키 저장
+     * @param redisKey - 인증 번호 레디스 키 값
+     * @param authNumber - 인증 번호 value
+     */
+    public void saveAuth(String redisKey, String authNumber) {
+        authRedisRepository.save(new RedisAuth(redisKey, authNumber));
+    }
+
+    /**
+     * 인증관련 레디스 키 value 매칭
+     * @param redisKey - 조회할 인증 번호 키
+     * @param authValue - 인증 관련 value
+     * @return true: 인증번호 일치, false: 인증번호 불일치
+     */
+    public boolean matchAuth(String redisKey, String authValue) {
+        Optional<RedisAuth> authToken = authRedisRepository.findById(redisKey);
+        if (authToken.isPresent()) {
+            return authToken.get().getValue().equals(authValue);
+        }
+        return false;
+    }
+
+    /**
+     * 토큰 생성
+     * @param memberSeq - 사용자 번호
+     * @return salt + memberSeq와 SHA256으로 암호화된 token 반환
+     */
+    public String getToken(int memberSeq) {
+        String authTokenText = authProperty.getSalt()+ memberSeq;
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            md.update(authTokenText.getBytes());
+            return bytesToHex(md.digest());
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * 암호화된 값 읽어들이는 메소드
+     * @param bytes
+     * @return
+     */
+    private String bytesToHex(byte[] bytes) {
+        StringBuilder builder = new StringBuilder();
+        for (byte b : bytes) {
+            builder.append(String.format("%02x", b));
+        }
+        return builder.toString();
+    }
+
+    /**
+     * 랜덤한 6자리 인증 번호를 반환
+     * @return 6자리 숫자로 된 번호 반환
+     */
+    public String getAuthNumber() {
+        return RandomStringUtils.randomNumeric(6);
+    }
+
+}

--- a/src/main/java/com/around/tdd/service/EmailSendService.java
+++ b/src/main/java/com/around/tdd/service/EmailSendService.java
@@ -1,0 +1,25 @@
+package com.around.tdd.service;
+
+import com.around.tdd.vo.MailDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailSendService {
+
+    private final JavaMailSender javaMailSender;
+
+    public void sendSimpleMessage(MailDto mailDto) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(mailDto.getFrom());
+        message.setTo(mailDto.getTo());
+        message.setSubject(mailDto.getTitle());
+        message.setText(mailDto.getContent());
+        javaMailSender.send(message);
+    }
+
+
+}

--- a/src/main/java/com/around/tdd/service/MemberService.java
+++ b/src/main/java/com/around/tdd/service/MemberService.java
@@ -1,0 +1,24 @@
+package com.around.tdd.service;
+
+import com.around.tdd.repository.MemberRepository;
+import com.around.tdd.vo.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    /**
+     * 사용자 정보를 조회한다
+     * @param memberSeq - 사용자 번호
+     * @return 사용자 정보를 반환한다
+     */
+    public Optional<Member> memberFindById(Long memberSeq){
+        return memberRepository.findById(memberSeq);
+    }
+}

--- a/src/main/java/com/around/tdd/util/HttpUtil.java
+++ b/src/main/java/com/around/tdd/util/HttpUtil.java
@@ -1,0 +1,13 @@
+package com.around.tdd.util;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+public class HttpUtil {
+
+    public static HttpHeaders createJsonHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return headers;
+    }
+}

--- a/src/main/java/com/around/tdd/vo/MailDto.java
+++ b/src/main/java/com/around/tdd/vo/MailDto.java
@@ -1,0 +1,18 @@
+package com.around.tdd.vo;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class MailDto {
+
+    private String from;
+    private String to;
+    private String title;
+    private String content;
+
+}

--- a/src/main/java/com/around/tdd/vo/Member.java
+++ b/src/main/java/com/around/tdd/vo/Member.java
@@ -1,10 +1,11 @@
 package com.around.tdd.vo;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.Objects;
 
 @Entity
 @Setter
@@ -14,10 +15,27 @@ public class Member {
     @Id
     @GeneratedValue
     private Long memberSeq;
-
+    @NotNull
     private String id;
-
+    @NotNull
     private String password;
-
+    @NotNull
     private Integer state;
+
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "memberSeq", referencedColumnName = "memberSeq")
+    private MemberInfo memberInfo;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Member member = (Member) o;
+        return Objects.equals(memberSeq, member.memberSeq) && Objects.equals(id, member.id) && Objects.equals(password, member.password);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(memberSeq, id, password);
+    }
 }

--- a/src/main/java/com/around/tdd/vo/MemberInfo.java
+++ b/src/main/java/com/around/tdd/vo/MemberInfo.java
@@ -1,0 +1,43 @@
+package com.around.tdd.vo;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+public class MemberInfo {
+
+    @Id
+    @GeneratedValue
+    private Integer memberSeq;
+
+    @OneToOne(mappedBy = "memberInfo")
+    private Member member;
+
+    private String socialNumber;
+
+    private String name;
+
+    private String phone;
+
+    private String email;
+
+    private String nick;
+
+    private String gender;
+
+    private LocalDateTime birth;
+
+    private String address;
+
+    private String detailAddress;
+
+    private String post;
+}

--- a/src/main/java/com/around/tdd/vo/MemberRequest.java
+++ b/src/main/java/com/around/tdd/vo/MemberRequest.java
@@ -1,0 +1,12 @@
+package com.around.tdd.vo;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MemberRequest {
+    private Long memberSeq;
+    private String authNumber;
+    private String authToken;
+}

--- a/src/main/java/com/around/tdd/vo/RedisAuth.java
+++ b/src/main/java/com/around/tdd/vo/RedisAuth.java
@@ -1,0 +1,28 @@
+package com.around.tdd.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.redis.core.RedisHash;
+
+import java.util.Objects;
+
+@Getter
+@RedisHash(value = "auth", timeToLive = 1800)
+@AllArgsConstructor
+public class RedisAuth {
+    private String id;
+    private String value;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RedisAuth that = (RedisAuth) o;
+        return Objects.equals(id, that.id) && Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, value);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,5 +7,7 @@ spring:
       - classpath:config/application-database.yml
       - classpath:config/application-jpa.yml
       - classpath:config/application-redis.yml
+      - classpath:config/application-email.yml
+      - classpath:config/application-auth.yml
 server:
   port: 80

--- a/src/main/resources/config/application-auth.yml
+++ b/src/main/resources/config/application-auth.yml
@@ -1,0 +1,7 @@
+spring:
+  config:
+    activate:
+      on-profile: default
+
+auth-property:
+  salt: ${auth.salt}

--- a/src/main/resources/config/application-email.yml
+++ b/src/main/resources/config/application-email.yml
@@ -1,0 +1,11 @@
+spring:
+  config:
+    activate:
+      on-profile: default
+
+mail:
+  protocol: ${mail.protocol}
+  host: ${mail.host}
+  port: ${mail.port}
+  username: ${mail.username}
+  password: ${mail.password}

--- a/src/test/java/com/around/tdd/config/EnableMockMvc.java
+++ b/src/test/java/com/around/tdd/config/EnableMockMvc.java
@@ -1,0 +1,22 @@
+package com.around.tdd.config;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@AutoConfigureMockMvc
+@Import(EnableMockMvc.Config.class)
+public @interface EnableMockMvc {
+    class Config {
+        @Bean
+        public CharacterEncodingFilter characterEncodingFilter() {
+            return new CharacterEncodingFilter("UTF-8", true);
+        }
+    }
+}

--- a/src/test/java/com/around/tdd/config/MailTestConfig.java
+++ b/src/test/java/com/around/tdd/config/MailTestConfig.java
@@ -1,0 +1,49 @@
+package com.around.tdd.config;
+
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@TestConfiguration
+public class MailTestConfig {
+
+    @Value("${mail.protocol}")
+    private String protocol;
+
+    @Value("${mail.host}")
+    private String host;
+
+    @Value("${mail.port}")
+    private Integer port;
+
+    @Value("${mail.username}")
+    private String username;
+
+    @Value("${mail.password}")
+    private String password;
+
+    @Bean
+    public JavaMailSenderImpl mailSender() {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+        javaMailSender.setProtocol(protocol);
+        javaMailSender.setHost(host);
+        javaMailSender.setPort(port);
+        javaMailSender.setUsername(username);
+        javaMailSender.setPassword(password);
+        javaMailSender.setJavaMailProperties(this.getProperties());
+        return javaMailSender;
+    }
+
+
+    private Properties getProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("mail.smtp.auth", "true");
+        properties.setProperty("mail.smtp.starttls.enable", "true");
+        return properties;
+    }
+
+}

--- a/src/test/java/com/around/tdd/config/RedisTestConfig.java
+++ b/src/test/java/com/around/tdd/config/RedisTestConfig.java
@@ -1,13 +1,13 @@
 package com.around.tdd.config;
 
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
-@Configuration
-public class RedisConfig {
+@TestConfiguration
+public class RedisTestConfig {
 
     @Bean
     public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {

--- a/src/test/java/com/around/tdd/controller/AuthControllerTest.java
+++ b/src/test/java/com/around/tdd/controller/AuthControllerTest.java
@@ -1,0 +1,177 @@
+package com.around.tdd.controller;
+
+import com.around.tdd.config.EnableMockMvc;
+import com.around.tdd.service.AuthService;
+import com.around.tdd.service.EmailSendService;
+import com.around.tdd.service.MemberService;
+import com.around.tdd.vo.MailDto;
+import com.around.tdd.vo.Member;
+import com.around.tdd.vo.MemberInfo;
+import com.around.tdd.vo.MemberRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@EnableMockMvc //한글 깨짐 방지
+@WebMvcTest(controllers = AuthController.class)
+class AuthControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    private AuthService authService;
+
+    @MockBean
+    private EmailSendService emailSendService;
+
+    @MockBean
+    private MemberService memberService;
+
+    private final String baseUrl = "/api/v1/auth";
+
+    @Test
+    @DisplayName("인증번호 저장 및 메일 발송 성공 테스트")
+    void authNumberSaveAndEmailSendTest() throws Exception {
+        // given
+        MemberRequest memberRequest = new MemberRequest();
+        memberRequest.setMemberSeq(1L);
+        Member member = new Member();
+        member.setMemberSeq(1L);
+        String content = objectMapper.writeValueAsString(memberRequest);
+
+        MemberInfo memberInfo = new MemberInfo();
+        memberInfo.setEmail("tarot1415@gmail.com");
+        member.setMemberInfo(memberInfo);
+        when(memberService.memberFindById(1L)).thenReturn(Optional.of(member));
+        when(authService.getAuthNumber()).thenReturn("123456");
+        //when & then
+        mockMvc.perform(MockMvcRequestBuilders.post(baseUrl+"/auth-number")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content)
+                )
+                .andExpect(status().isCreated())
+                .andExpect(content().string("인증번호 저장 성공"));
+        //then
+        verify(authService).saveAuth(eq("auth-member:1"), eq("123456"));
+        verify(emailSendService).sendSimpleMessage(any(MailDto.class));
+    }
+
+    @Test
+    @DisplayName("사용자 정보가 없을 때 204 응답")
+    void authNumberMemberNotFound() throws Exception {
+        // Given
+        MemberRequest memberRequest = new MemberRequest();
+        memberRequest.setMemberSeq(1L);
+        String content = objectMapper.writeValueAsString(memberRequest);
+        Mockito.when(memberService.memberFindById(99999L)).thenReturn(Optional.empty());
+
+        // When & Then
+        mockMvc.perform(MockMvcRequestBuilders.post(baseUrl+"/auth-number")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content)
+                )
+                .andExpect(status().isNoContent())
+                .andExpect(content().string("사용자 정보가 없음"));
+
+        // Then
+        verify(authService, never()).getAuthNumber();
+        verify(authService, never()).saveAuth(any(), any());
+        verify(emailSendService, never()).sendSimpleMessage(any(MailDto.class));
+    }
+
+    @Test
+    @DisplayName("인증번호가 일치했을 토큰값 반환 테스트")
+    void authCheckSuccessTokenSaveTest() throws Exception {
+        //given
+        MemberRequest memberRequest = new MemberRequest();
+        memberRequest.setMemberSeq(1L);
+        memberRequest.setAuthNumber("123456");
+        String content = objectMapper.writeValueAsString(memberRequest);
+        String redisKey = "auth-member:"+memberRequest.getMemberSeq();
+        String token = "1b4f0e9851971998e732078544c96b36c3d01cedf7caa332359d6f1d83567014";
+
+
+        when(authService.getToken(memberRequest.getMemberSeq().intValue())).thenReturn(token);
+        when(authService.matchAuth(redisKey, memberRequest.getAuthNumber())).thenReturn(true);
+        mockMvc.perform(MockMvcRequestBuilders.post(baseUrl+"/auth-check")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content)
+                )
+                .andExpect(status().isCreated())
+                .andExpect(content().string("1b4f0e9851971998e732078544c96b36c3d01cedf7caa332359d6f1d83567014"));
+        verify(authService).saveAuth(eq("auth-token:"+memberRequest.getMemberSeq()), eq(token));
+    }
+
+    @Test
+    @DisplayName("인증번호가 일치하지 않았을때 테스트")
+    void authCheckFailTokenTest() throws Exception {
+        //given
+        MemberRequest memberRequest = new MemberRequest();
+        memberRequest.setMemberSeq(1L);
+        memberRequest.setAuthNumber("123456");
+        String content = objectMapper.writeValueAsString(memberRequest);
+        String redisKey = "auth-member:"+memberRequest.getMemberSeq();
+
+        when(authService.matchAuth(redisKey, memberRequest.getAuthNumber())).thenReturn(false);
+        mockMvc.perform(MockMvcRequestBuilders.post(baseUrl+"/auth-check")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content)
+                )
+                .andExpect(status().isNoContent())
+                .andExpect(content().string("false"));
+        verify(authService, never()).saveAuth(redisKey, memberRequest.getAuthNumber());
+    }
+
+    @Test
+    @DisplayName("인증 토큰 일치/불일치 테스트")
+    void authTokenTest() throws Exception {
+        //given
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+
+        params.add("memberSeq", "1");
+        params.add("authToken", "1b4f0e9851971998e732078544c96b36c3d01cedf7caa332359d6f1d83567014");
+
+        String redisKey = "auth-token:1";
+        when(authService.matchAuth(redisKey, "1b4f0e9851971998e732078544c96b36c3d01cedf7caa332359d6f1d83567014")).thenReturn(true);
+        //when & then
+        mockMvc.perform(MockMvcRequestBuilders.get(baseUrl+"/auth-token-check")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .params(params)
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().string("true"));
+
+        params.add("authToken", "60303ae22b998861bce3b28f33eec1be758a213c86c93c076dbe9f558c11c752");
+        when(authService.matchAuth(redisKey, "60303ae22b998861bce3b28f33eec1be758a213c86c93c076dbe9f558c11c752")).thenReturn(false);
+        //when & then
+        mockMvc.perform(MockMvcRequestBuilders.get(baseUrl+"/auth-token-check")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .params(params)
+                )
+                .andExpect(status().isNoContent())
+                .andExpect(content().string("false"));
+    }
+}

--- a/src/test/java/com/around/tdd/repository/AuthRedisRepositoryTest.java
+++ b/src/test/java/com/around/tdd/repository/AuthRedisRepositoryTest.java
@@ -1,0 +1,38 @@
+package com.around.tdd.repository;
+
+import com.around.tdd.vo.RedisAuth;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@TestPropertySource("classpath:application-test.yml")
+@DataRedisTest
+class AuthRedisRepositoryTest {
+
+    @Autowired
+    private AuthRedisRepository authRedisRepository;
+
+    @ParameterizedTest
+    @CsvSource({"1,111111", "2,222222", "3,333333"})
+    @DisplayName("인증 번호 6자리를 redis의 저장")
+    void authNumberSaveTest(Integer memberSeq, String authNumber){
+        //given
+        String id = "member-auth:"+memberSeq;
+        String value = authNumber;
+        RedisAuth redisAuth = new RedisAuth(id, value);
+        authRedisRepository.save(redisAuth);
+        Optional<RedisAuth> resultRedisAuthToken = authRedisRepository.findById(id);
+        assertThat(resultRedisAuthToken.get()).isEqualTo(redisAuth);
+    }
+
+
+}

--- a/src/test/java/com/around/tdd/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/around/tdd/repository/MemberRepositoryTest.java
@@ -1,0 +1,52 @@
+package com.around.tdd.repository;
+
+import com.around.tdd.vo.Member;
+import com.around.tdd.vo.MemberInfo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@ActiveProfiles("test")
+@TestPropertySource("classpath:application-test.yml")
+@DataJpaTest
+class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @DisplayName("회원 정보 조회 테스트")
+    @Test
+    void memberInfoFindTest(){
+        Member member = new Member();
+        member.setMemberSeq(1L);
+        member.setId("junha1");
+        member.setPassword("!!q1w2e3r4");
+        member.setState(1);
+        MemberInfo memberInfo = new MemberInfo();
+        memberInfo.setSocialNumber("9603291111111");
+        memberInfo.setName("황준하");
+        memberInfo.setEmail("tarot10@naver.com");
+        memberInfo.setPhone("01084282511");
+        memberInfo.setNick("taro1");
+        memberInfo.setGender("M");
+        memberInfo.setAddress("서울특별시 관악구 신림동 1415-10");
+        memberInfo.setDetailAddress("아덴빌 204호");
+        memberInfo.setPost("08755");
+        memberInfo.setBirth(LocalDateTime.of(1996, 03, 29, 0, 0, 0));
+        member.setMemberInfo(memberInfo);
+        Member savedMember = memberRepository.save(member);
+        List<Member> resultMember = memberRepository.findAll();
+
+        assertThat(resultMember.get(0)).isEqualTo(member);
+    }
+
+}

--- a/src/test/java/com/around/tdd/service/AuthServiceTest.java
+++ b/src/test/java/com/around/tdd/service/AuthServiceTest.java
@@ -1,0 +1,73 @@
+package com.around.tdd.service;
+
+import com.around.tdd.property.AuthProperty;
+import com.around.tdd.repository.AuthRedisRepository;
+import com.around.tdd.vo.RedisAuth;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Mock
+    private AuthRedisRepository authRedisRepository;
+
+    @Mock
+    private AuthProperty authProperty;
+
+    @DisplayName("인증 번호 저장 테스트")
+    @ParameterizedTest
+    @CsvSource({"member-auth:1,111111","member-auth:2,222222"})
+    void saveAuthTest(String redisKey, String authNumber){
+        authService.saveAuth(redisKey, authNumber);
+        verify(authRedisRepository, times(1)).save(any(RedisAuth.class));
+    }
+
+    @DisplayName("인증 번호 매치 테스트")
+    @ParameterizedTest
+    @CsvSource({"member-auth:1,111111","member-auth:2,222222"})
+    void matchAuthTest(String redisKey, String authNumber){
+        RedisAuth redisAuth = new RedisAuth(redisKey, authNumber);
+        when(authRedisRepository.findById(redisKey)).thenReturn(Optional.of(redisAuth));
+        boolean result = authService.matchAuth(redisKey, authNumber);
+        assertThat(result).isTrue();
+    }
+
+    @DisplayName("인증 토큰 값 테스트")
+    @ParameterizedTest
+    @CsvSource({"1,1b4f0e9851971998e732078544c96b36c3d01cedf7caa332359d6f1d83567014","2,60303ae22b998861bce3b28f33eec1be758a213c86c93c076dbe9f558c11c752"})
+    void getTokenTest(int memberSeq, String matchToken){
+        when(authProperty.getSalt()).thenReturn("test");
+        String token = authService.getToken(memberSeq);
+        assertThat(token).isNotNull();
+        assertThat(token).hasSize(64);
+        assertThat(token).isEqualTo(matchToken);
+    }
+
+    @DisplayName("인증 번호 유효 테스트")
+    @Test
+    void getAuthNumberTest(){
+        String authNumber = authService.getAuthNumber();
+
+        assertThat(authNumber).isNotNull();
+        assertThat(authNumber).hasSize(6);
+    }
+
+
+
+
+}

--- a/src/test/java/com/around/tdd/service/EmailSendServiceTest.java
+++ b/src/test/java/com/around/tdd/service/EmailSendServiceTest.java
@@ -1,0 +1,42 @@
+package com.around.tdd.service;
+
+import com.around.tdd.vo.MailDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class EmailSendServiceTest {
+
+    @InjectMocks
+    private EmailSendService emailSendService;
+
+    @Mock
+    private JavaMailSender javaMailSender;
+
+    @ParameterizedTest
+    @MethodSource("emailDtoProvider")
+    @DisplayName("이메일 발송 테스트")
+    void sendSimpleMessageTest(MailDto mailDto) {
+        emailSendService.sendSimpleMessage(mailDto);
+        verify(javaMailSender, atLeastOnce()).send(any(SimpleMailMessage.class)); // AuthService의 메서드 호출 검증
+    }
+
+    private static Stream<MailDto> emailDtoProvider() {
+        return Stream.of(
+                new MailDto("tarot1415@gmail.com", "tarot10@naver.com", "인증번호", "인증번호: 999999")
+        );
+    }
+}

--- a/src/test/java/com/around/tdd/service/MemberServiceTest.java
+++ b/src/test/java/com/around/tdd/service/MemberServiceTest.java
@@ -1,0 +1,43 @@
+package com.around.tdd.service;
+
+import com.around.tdd.repository.MemberRepository;
+import com.around.tdd.vo.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @DisplayName("사용자 정보 조회")
+    void memberFindByIdTest(){
+        Long memberSeq = 1L;
+        String id = "junha1";
+        String password = "!!1q2w3e4r";
+        Integer state = 1;
+        Member member = new Member();
+        member.setMemberSeq(memberSeq);
+        member.setId(id);
+        member.setPassword(password);
+        member.setState(state);
+        when(memberRepository.findById(memberSeq)).thenReturn(Optional.of(member));
+
+        Optional<Member> resultMember = memberService.memberFindById(memberSeq);
+
+        assertThat(resultMember.isPresent()).isTrue();
+        assertThat(resultMember.get().getId()).isEqualTo(id);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -7,3 +7,5 @@ spring:
       - classpath:config/application-jpa.yml
       - classpath:config/application-log.yml
       - classpath:config/application-redis.yml
+      - classpath:config/application-email.yml
+      - classpath:config/application-auth.yml

--- a/src/test/resources/config/application-auth.yml
+++ b/src/test/resources/config/application-auth.yml
@@ -1,0 +1,7 @@
+spring:
+  config:
+    activate:
+      on-profile: test
+
+auth-property:
+  salt: ${auth.salt}

--- a/src/test/resources/config/application-email.yml
+++ b/src/test/resources/config/application-email.yml
@@ -1,0 +1,10 @@
+spring:
+  config:
+    activate:
+      on-profile: test
+mail:
+  protocol: ${mail.protocol}
+  host: ${mail.host}
+  port: ${mail.port}
+  username: ${mail.username}
+  password: ${mail.password}


### PR DESCRIPTION
- 이메일 발송을 위한 세팅 추가
- 이메일 및 salt값 환경 변수 추가
- 랜덤한 6자리의 번호를 생성한다
- 저장된 혹은 요청된 이메일로 6자리 인증번호를 보낸다
- 인증번호를 Redis의 저장하고 30분 동안 유효시간을 설정한다
- 사용자가 인증번호를 입력하고 해당 번호를 redis에서 확인한다
- 값이 확인 되면  사용자 번호 + 지정된 salt로 암호화 알고리즘을 적용해서 토큰을 하나 생성한다
- 발급된 토큰을 redis의 저장을 하고 30분간 저장을 한다
- 발급된 토큰을 반환한다